### PR TITLE
Check webworker data before running workerMethods

### DIFF
--- a/src/modules/core/processFrameWorker.js
+++ b/src/modules/core/processFrameWorker.js
@@ -13,10 +13,9 @@ define([
   var workerCode = function () {
     try {
       self.onmessage = function(ev) {
-        var data = ev.data,
-          response = workerMethods.run(data);
-
-        if (data && data.gifshot) {
+        var data = ev.data;
+        if (data && data.gifshot){
+          var response = workerMethods.run(data);
           postMessage(response);
         }
       };


### PR DESCRIPTION
When multiple apps on a page are using Web Workers, Gifshot does not verify that the message is actually for it before it runs workerMethods.run(data). 
That leads to workerMethods.processFrameWithQuantizer being called with bad arguments and the page throws the error: "TypeError: Invalid array length argument (fractional lengths not allowed)".

This change checks that the web worker message includes gifshot data before passing it along.