### PR TITLE
Added progressCallback support for createGIF() with images

### DIFF
--- a/src/modules/API/createGIF.js
+++ b/src/modules/API/createGIF.js
@@ -24,6 +24,7 @@ define([
       lastCameraStream = userOptions.cameraStream,
       images = options.images,
       imagesLength = images ? images.length : 0,
+      progressCallback = userOptions.progressCallback,
       video = options.video,
       webcamVideoElement = options.webcamVideoElement;
 

--- a/src/modules/core/AnimatedGIF.js
+++ b/src/modules/core/AnimatedGIF.js
@@ -92,7 +92,7 @@ define([
 
       return str;
     },
-    'onFrameFinished': function() {
+    'onFrameFinished': function (progressCallback) {
       // The GIF is not written until we're done with all the frames
       // because they might not be processed in the same order
       var self = this,
@@ -102,6 +102,7 @@ define([
         });
 
       self.numRenderedFrames++;
+      progressCallback(self.numRenderedFrames / frames.length);
       self.onRenderProgressCallback(self.numRenderedFrames * 0.75 / frames.length);
 
       if (allDone) {
@@ -118,6 +119,7 @@ define([
     'processFrame': function(position) {
       var AnimatedGifContext = this,
         options = this.options,
+        progressCallback = options.progressCallback,
         sampleInterval = options.sampleInterval,
         frames = this.frames,
         frame,
@@ -135,7 +137,7 @@ define([
 
           AnimatedGifContext.freeWorker(worker);
 
-          AnimatedGifContext.onFrameFinished();
+          AnimatedGifContext.onFrameFinished(progressCallback);
         };
 
       frame = frames[position];


### PR DESCRIPTION
When calling gifshot.createGIF() with a function for the progressCallback option, the function never gets called for images but does get called for videos. This change adds support for progressCallback when using images as the GIF source.