### PR TITLE
Use `screenShot.getGIF` instead of outdated (non-existing) `screenshot.getWebcamGIF` method when using `savedRenderingContexts`

### DIFF
--- a/src/modules/core/existingWebcam.js
+++ b/src/modules/core/existingWebcam.js
@@ -23,7 +23,7 @@ define([
       return callback(error.validate());
     }
     if (options.savedRenderingContexts.length) {
-      screenShot.getWebcamGIF(options, function(obj) {
+      screenShot.getGIF(options, function(obj) {
         callback(obj);
       });
       return;


### PR DESCRIPTION
The `existingWebcam` module uses a undefined method of the `screenShot` module. The method `getWebcamGIF` [was renamed in 0.1.0](https://github.com/yahoo/gifshot/commit/f8c4cfd76318717d70fd14b985aca6e26063c67d#diff-1c708e11017f70f8391fab858f1dbb95L1229)
