### PR TITLE
Fixed typo, which solved issue #104 in /yahoo/gifshot.

### DIFF
--- a/src/modules/core/AnimatedGIF.js
+++ b/src/modules/core/AnimatedGIF.js
@@ -238,7 +238,7 @@ AnimatedGIF.prototype = {
 
           onRenderProgressCallback(0.75 + 0.25 * frame.position * 1.0 / frames.length);
 
-          for (let i = 0; i < frameDuration; i ++) {
+          for (let i = 0; i < frameDuration; i++) {
               gifWriter.addFrame(0, 0, width, height, frame.pixels, {
                   palette: framePalette,
                   delay: delay


### PR DESCRIPTION
Fixed bug that caused gifshot to ignore frame duration option. This typo fix solves the bug.